### PR TITLE
Fix CI not running on pull requests

### DIFF
--- a/files/.github/workflows/main.yml
+++ b/files/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   check:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
I noticed that the CI of libraries is not triggered on pull requests. Hopefully this change fixes that...