### PR TITLE
PR template: Remove superfluous linebreaks

### DIFF
--- a/files/.github/pull_request_template.md
+++ b/files/.github/pull_request_template.md
@@ -24,7 +24,6 @@ is needed. -->
 - [ ] I'm the copyright owner of the added content (i.e. the changes are made by myself, not copied/imported from somewhere else).
 - [ ] I agree to publish all my changes under the CC0 Public Domain License³, allowing everyone to use and modify the content without any restrictions.
 
-¹ *Library Conventions: https://docs.librepcb.org/#libraryconventions*</br>
-² *Minor version bump if only metadata was modified (e.g. "0.1" -> "0.1.1"),
-  major version bump if functional changes were made (e.g. "0.1" -> "0.2")*</br>
-³ *CC0 Public Domain License: https://en.wikipedia.org/wiki/CC0*</br>
+¹ *Library Conventions: https://docs.librepcb.org/#libraryconventions*
+² *Minor version bump if only metadata was modified (e.g. "0.1" -> "0.1.1"), major version bump if functional changes were made (e.g. "0.1" -> "0.2")*
+³ *CC0 Public Domain License: https://en.wikipedia.org/wiki/CC0*


### PR DESCRIPTION
Now I remember why #3 was lying around for weeks without opening the PR yet :sob: Somehow the linebreaks were messed up in the rendered markdown:

![image](https://user-images.githubusercontent.com/5374821/103318331-6f3aaf00-4a2e-11eb-991d-6ce409106998.png)

Now without the linebreaks in the markdown, it looks better:

![image](https://user-images.githubusercontent.com/5374821/103318362-86799c80-4a2e-11eb-995c-029a271f7c7f.png)