### PR TITLE
Extend script to support upgrading file format & deploy v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ Create a file `options.json` with following content:
 ## Deploy To All Libraries
 
     ./deploy.py --apply
+
+## Upgrade Libraries File Format
+
+To upgrade libraries to a new file format, you need to have Docker installed.
+Then run the following command (combined with the flags documented above):
+
+    ./deploy.py --upgrade 1.0.0-rc1
+
+With `1.0.0-rc1` representing the tag of the `librepcb/librepcb-cli` Docker
+image to be used for the upgrade.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Create a file `options.json` with following content:
 
     ./deploy.py
 
-## Deploy To LibrePCB_Base.lplib
+## Deploy Only To LibrePCB_Base.lplib
 
-    ./deploy.py --single --apply
+    ./deploy.py --apply LibrePCB_Base.lplib
 
 ## Deploy To All Libraries
 

--- a/files/.github/workflows/main.yml
+++ b/files/.github/workflows/main.yml
@@ -2,10 +2,10 @@ name: CI
 on: [push, pull_request]
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: librepcb/librepcb-cli:0.1.5
+      image: librepcb/librepcb-cli:1.0.0-rc1
       options: --entrypoint /bin/bash
     steps:
     - uses: actions/checkout@v1
-    - run: librepcb-cli open-library --all --strict .
+    - run: librepcb-cli open-library --all --strict --minify-step .


### PR DESCRIPTION
Extending the script to support upgrading all libraries to the latest file format (using the Docker image `librepcb/librepcb-cli`). In addition, updated the template CI config to use the new LibrePCB version also for the CI of libraries.

Deployed to LibrePCB_Base.lplib for a first test: https://github.com/LibrePCB-Libraries/LibrePCB_Base.lplib/pull/106

Will deploy it to all other libraries as well.